### PR TITLE
Set 'allow-stderr' input to always complete a job successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
           job: parameterized-job
           namespace: my-namespace
           parameterized: true
-          allow-failure: true
+          allow-stderr: true
 ```
 
 Combine with vault-action
@@ -89,7 +89,7 @@ jobs:
 - `namespace`: Namespace of the nomad job
 - `job`: Name of the nomad job
 - `parameterized`: Set to true if the nomad job is parameterized
-- `allow-failure`: Set to true so that the action completes successfully if logs are detected on stderr
+- `allow-stderr`: Set to true so that the action completes successfully if logs are detected on stderr
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
           job: example-job
 ```
 
-Get logs from a parameterized job in a specific namespace
+Get logs from a parameterized job in a specific namespace and always complete successfully
 
 ```yml
 name: Get logs from Nomad Job
@@ -46,6 +46,7 @@ jobs:
           job: parameterized-job
           namespace: my-namespace
           parameterized: true
+          allow-failure: true
 ```
 
 Combine with vault-action
@@ -88,6 +89,7 @@ jobs:
 - `namespace`: Namespace of the nomad job
 - `job`: Name of the nomad job
 - `parameterized`: Set to true if the nomad job is parameterized
+- `allow-failure`: Set to true so that the action completes successfully if logs are detected on stderr
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Set to true if the nomad job is parameterized"
     required: false
     default: "false"
+  allow-failure:
+    description: "Set to true so that the action completes successfully if logs are detected on stderr"
+    required: false
+    default: "false"
 outputs:
   status:
     description: "Indicates the success or failure of the running tasks"
@@ -41,3 +45,4 @@ runs:
         NOMAD_JOB: ${{ inputs.job }}
         NOMAD_NAMESPACE: ${{ inputs.namespace }}
         PARAMETERIZED_JOB: ${{ inputs.parameterized }}
+        ALLOW_FAILURE: ${{ inputs.allow-failure}}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: "Set to true if the nomad job is parameterized"
     required: false
     default: "false"
-  allow-failure:
+  allow-stderr:
     description: "Set to true so that the action completes successfully if logs are detected on stderr"
     required: false
     default: "false"
@@ -45,4 +45,4 @@ runs:
         NOMAD_JOB: ${{ inputs.job }}
         NOMAD_NAMESPACE: ${{ inputs.namespace }}
         PARAMETERIZED_JOB: ${{ inputs.parameterized }}
-        ALLOW_FAILURE: ${{ inputs.allow-failure}}
+        ALLOW_STDERR: ${{ inputs.allow-stderr }}

--- a/status.sh
+++ b/status.sh
@@ -9,6 +9,7 @@ set -o pipefail
 # NOMAD_ADDR=""
 # NOMAD_NAMESPACE=""
 # PARAMETERIZED_JOB="(true|false)"
+# ALLOW_FAILURE="(true|false)"
 
 function eval_variable {
   local var=$(eval "${1}")
@@ -166,10 +167,14 @@ output_content="${output_content//$'\n'/'%0A'}"
 output_content="${output_content//$'\r'/'%0D'}"
 
 if [[ "${output_status}" =~ "failure" ]]; then
-  echo "::set-output name=status::failure"
   echo "::set-output name=content::${output_content}"
-  exit 1
+  if [[ "${ALLOW_FAILURE}" == "true" ]]; then 
+    echo "::set-output name=status::success"
+  else
+    echo "::set-output name=status::failure"
+    exit 1
+  fi
 else
-  echo "::set-output name=status::success"
   echo "::set-output name=content::${output_content}"
+  echo "::set-output name=status::success"
 fi

--- a/status.sh
+++ b/status.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # NOMAD_ADDR=""
 # NOMAD_NAMESPACE=""
 # PARAMETERIZED_JOB="(true|false)"
-# ALLOW_FAILURE="(true|false)"
+# ALLOW_STDERR="(true|false)"
 
 function eval_variable {
   local var=$(eval "${1}")
@@ -168,7 +168,7 @@ output_content="${output_content//$'\r'/'%0D'}"
 
 if [[ "${output_status}" =~ "failure" ]]; then
   echo "::set-output name=content::${output_content}"
-  if [[ "${ALLOW_FAILURE}" == "true" ]]; then 
+  if [[ "${ALLOW_STDERR}" == "true" ]]; then 
     echo "::set-output name=status::success"
   else
     echo "::set-output name=status::failure"


### PR DESCRIPTION
When we just need to display logs from stderr without sending an exit code 1.
This can be useful to ignore stderr logs detected during a deployment.